### PR TITLE
Adding unit tests for domains methods

### DIFF
--- a/examples/create_domains.js
+++ b/examples/create_domains.js
@@ -1,0 +1,12 @@
+let scalingo = require('../dist/scalingo.js');
+
+scalingo.clientFromToken(process.env.SCALINGO_TOKEN).then((client)=>{
+    return client.Domains.create("scalingo-js-tests",
+        {
+            name: "test.de",
+            tlscert: null,
+            tlskey: null
+        });
+}).then((domains) => {
+    console.log(domains)
+});

--- a/examples/destroy_domains.js
+++ b/examples/destroy_domains.js
@@ -1,0 +1,10 @@
+let scalingo = require('../dist/scalingo.js');
+
+scalingo.clientFromToken(process.env.SCALINGO_TOKEN).then((client)=>{
+    return client.Domains.destroy("scalingo-js-tests", "5cb0535400de8f000f5959ae")
+}).then((domains) => {
+    console.log(domains)
+}).catch(e => {
+    console.log("Status code =>", e._status);
+    console.log("Response =>", e._data);
+})

--- a/examples/show_domains.js
+++ b/examples/show_domains.js
@@ -1,0 +1,10 @@
+let scalingo = require('../dist/scalingo.js');
+
+scalingo.clientFromToken(process.env.SCALINGO_TOKEN).then((client)=>{
+    return client.Domains.show("scalingo-js-tests", "5cb0467bb18a470010a6e0b1")
+}).then((domains) => {
+    console.log(domains);
+}).catch(e => {
+    console.log("Status code =>", e._status);
+    console.log("Response =>", e._data);
+})

--- a/src/Domains/index.js
+++ b/src/Domains/index.js
@@ -30,7 +30,7 @@ export default class Domains {
      * @return {Promise<Domain | APIError>}
      */
     create(appId, domain) {
-        return unpackData(this._client.apiClient().post(`/apps/${appId}/domains`, {domain: domain}), "domains")
+        return unpackData(this._client.apiClient().post(`/apps/${appId}/domains`, {domain: domain}), "domain")
     }
 
     /**

--- a/test/Domains/index.test.js
+++ b/test/Domains/index.test.js
@@ -9,7 +9,7 @@ describe("Domains#for", () => {
 });
 
 describe("Domains#create", () => {
-    testPost("https://api.scalingo.com/v1/apps/tata/domains", { domain: { name: 'nice.one.dude', tlscert: null,  tlskey: null } }, 'domains',(client) => {
+    testPost("https://api.scalingo.com/v1/apps/tata/domains", { domain: { name: 'nice.one.dude', tlscert: null,  tlskey: null } }, 'domain',(client) => {
         return new Domains(client).create("tata", { name: 'nice.one.dude', tlscert: null,  tlskey: null })
     })
 });


### PR DESCRIPTION
Fix #22 

Those unit tests are used to call the API and test responses.