### PR TITLE
Error management produced errors on firefox

### DIFF
--- a/examples/create_domains.js
+++ b/examples/create_domains.js
@@ -9,4 +9,4 @@ scalingo.clientFromToken(process.env.SCALINGO_TOKEN).then((client)=>{
         });
 }).then((domains) => {
     console.log(domains)
-});
+})

--- a/src/errors.js
+++ b/src/errors.js
@@ -17,7 +17,11 @@ export class APIError extends Error{
     this._data = data
 
     // Remove ourself from the stack trace
-    Error.captureStackTrace(this, APIError)
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, APIError)
+    } else {
+      this.stack = new Error(this._status + this._data).stack
+    }
   }
 
   /**


### PR DESCRIPTION
Fix #24 

We needed to add a condition to check if it is possible to use `Error.captureStackTrace()` or not and use `this.stack = new Error().stack` instead.