### PR TITLE
Lint: remove TS config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,22 +4,13 @@ module.exports = {
     mocha: true,
     node: true,
   },
-  extends: [
-    'prettier',
-    'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
-    'plugin:prettier/recommended',
-    'eslint:recommended',
-  ],
+  extends: ['prettier', 'plugin:prettier/recommended', 'eslint:recommended'],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
   },
-  plugins: ['@typescript-eslint'],
   rules: {
     'no-extra-semi': 'off',
-    '@typescript-eslint/camelcase': 'warn',
-    '@typescript-eslint/no-use-before-define': 'warn',
   },
   parserOptions: {
     ecmaVersion: 2018,


### PR DESCRIPTION
Removes the TS configuration from `eslint`. Produces lots of warning and TS is not enabled for this project. This should be properly re-introduced with #78