### PR TITLE
chore(ci): update node versions used in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,17 +11,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Using Node.js ${{ matrix.node-version }}
+    - name: Using Node.js 18 (LTS)
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '18.x'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,17 +13,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Using Node.js ${{ matrix.node-version }}
+    - name: Using Node.js 18 (LTS)
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '18.x'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Using Node.js 14
+    - name: Using Node.js 18 (LTS)
       uses: actions/setup-node@v2
       with:
-        node-version: '14.x'
+        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
     - run: yarn install --frozen-lockfile
     - run: yarn build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * chore: bump dependencies
+* versions: dropping node 14, no longer maintained. Adds 20.x to test matrix
 
 ## 0.8.2
 


### PR DESCRIPTION
Node 14 is no longer maintained, dropping official support for it (cf https://endoflife.date/nodejs)

Also slightly improves workflow files (there's likely way better/simpler to do but this will work for now)

<img width="753" alt="Screenshot 2023-07-19 at 09 41 06" src="https://github.com/Scalingo/scalingo.js/assets/228701/ba1806b2-deae-41a0-ac05-341c6e471ffd">
