### PR TITLE
Remove ksol from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,3 @@ updates:
           - "typedoc"
     reviewers:
       - "aurelien-reeves-scalingo"
-      - "ksol"


### PR DESCRIPTION
Ref https://github.com/Scalingo/scalingo.js/pull/402#issuecomment-2510218799

```
POST https://api.github.com/repos/Scalingo/scalingo.js/pulls/402/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the Scalingo/scalingo.js repository. // See: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
```