### PR TITLE
Add a "prepare" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "npm run lint:ts && npm run lint:js",
     "lint:js": "eslint --ext .js,.ts ./src ./test",
     "lint:ts": "tsc --noEmit",
-    "test": "mocha --require @babel/register --require ts-node/register ./test/**.test.js ./test/**/*.test.js"
+    "test": "mocha --require @babel/register --require ts-node/register ./test/**.test.js ./test/**/*.test.js",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "axios": "^1.3.1",


### PR DESCRIPTION
Goal: Allow us to target a particular branch/commit SHA (mostly for development purpose).

Adding this to the main repo, along with something like "scalingo": github:Scalingo/scalingo.js#master' to the 'package.json' file in a project using the 'scalingo.js' library. This will allow us to easily target a specific branch or commit SHA without any complicated processes.

I had to add this script because adding only `"scalingo": "github:Scalingo/scalingo.js#master"` to the `package.json` file in a project using the scalingo.js library results in an unusable, non-built scalingo.js library in the `node_modules` folder.

cf: https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts