### PR TITLE
[STORY-1430] fix(collaborators/invite) Make it accept both a payload and a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.14.1
+
 * feat: add `flags` to `Project` interface
 * feat: accept `Collaborator payload` in `Collaborators` invitation endpoint
 

--- a/src/Collaborators/index.ts
+++ b/src/Collaborators/index.ts
@@ -61,8 +61,11 @@ export default class Collaborators {
    */
   invite(
     appId: string,
-    payload: Collaborator,
+    payload: Collaborator | string,
   ): Promise<CollaboratorInvitation> {
+    if (typeof payload === "string") {
+      payload = { email: payload } as Collaborator;
+    }
     return unpackData(
       this._client.apiClient().post(`/apps/${appId}/collaborators`, {
         collaborator: {

--- a/test/Collaborators/index.test.js
+++ b/test/Collaborators/index.test.js
@@ -44,6 +44,18 @@ describe("Collaborators#invite", () => {
   );
 });
 
+describe("Collaborators#invite using an email address only", () => {
+  testPost(
+    "https://api.osc-fr1.scalingo.com/v1/apps/toto/collaborators",
+    null,
+    { collaborator: { email: "toto@titi.tata" } },
+    "collaborator",
+    (client) => {
+      return new Collaborators(client).invite("toto", "toto@titi.tata");
+    },
+  );
+});
+
 describe("Collaborators#inviteAccept", () => {
   testParamsGetter(
     "https://api.osc-fr1.scalingo.com/v1/apps/collaboration",


### PR DESCRIPTION
Recent changes was breaking the API.
Making `colalborators.invite` accept both a payload and a string avoid
such breaking change