### PR TITLE
fix(databases.create): Rename 'database_name' param

### DIFF
--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -35,7 +35,7 @@ export default class Databases {
    * Create a new database
    * @param addon_provider_id ID of the addon provider
    * @param plan_id ID of the plan
-   * @param database_name Name of the database
+   * @param name Name of the database
    *
    * @return Promise that when resolved returns the new database.
    */

--- a/src/models/regional/databases.ts
+++ b/src/models/regional/databases.ts
@@ -105,7 +105,7 @@ export interface CreateParams {
   /** ID of the plan */
   plan_id: string;
   /** Name of the database */
-  database_name: string;
+  name: string;
   /** ID of the project (optional) */
   project_id?: string;
 }

--- a/test/Databases/index.test.js
+++ b/test/Databases/index.test.js
@@ -31,7 +31,7 @@ describe("Databases#create", () => {
       database: {
         addon_provider_id: "provider-id",
         plan_id: "plan-id",
-        database_name: "db-name",
+        name: "db-name",
       },
     },
     "apps",
@@ -39,7 +39,7 @@ describe("Databases#create", () => {
       return new Databases(client).create({
         addon_provider_id: "provider-id",
         plan_id: "plan-id",
-        database_name: "db-name",
+        name: "db-name",
       });
     },
   );


### PR DESCRIPTION
API is being changed to rename the 'database_name' param into 'name'