### PR TITLE
[STORY-3688] tech(move db-api > api): Move firewall rules endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## to be released
 
+* feat: add DBaaS firewall rules support in `Databases` client
+
 ## 0.18.2
 
 * feat: add `apiOperationShow()` method to fetch a single database operation by ID

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -13,6 +13,8 @@ import {
   LogsArchivesResult,
   DatabaseType,
   DatabaseTypeVersion,
+  FirewallRule,
+  FirewallManagedRange,
   DbOperation,
 } from "../models/regional/databases";
 import { unpackData } from "../utils";
@@ -280,6 +282,40 @@ export default class Databases {
         action_name: actionName,
         params: actionParams || {},
       }),
+    );
+  }
+
+  apiFirewallRules(addonId: string): Promise<FirewallRule[]> {
+    return unpackData(
+      this._client.dbaasApiClient().get(`/databases/${addonId}/firewall_rules`),
+      "rules",
+    );
+  }
+
+  apiCreateFirewallRule(
+    addonId: string,
+    params: { type: string; cidr?: string; label?: string; range_id?: string },
+  ): Promise<FirewallRule> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .post(`/databases/${addonId}/firewall_rules`, { firewall_rule: params }),
+      "rule",
+    );
+  }
+
+  apiDeleteFirewallRule(addonId: string, ruleId: string): Promise<void> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .delete(`/databases/${addonId}/firewall_rules/${ruleId}`),
+    );
+  }
+
+  apiManagedFirewallRanges(): Promise<FirewallManagedRange[]> {
+    return unpackData(
+      this._client.dbaasApiClient().get("/firewall/managed_ranges"),
+      "ranges",
     );
   }
 

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -16,6 +16,7 @@ import {
   FirewallRule,
   FirewallManagedRange,
   FirewallRuleCreateParams,
+  FirewallRuleUpdateParams,
   DbOperation,
 } from "../models/regional/databases";
 import { unpackData } from "../utils";
@@ -312,6 +313,21 @@ export default class Databases {
       this._client
         .dbaasApiClient()
         .delete(`/databases/${addonId}/firewall_rules/${ruleId}`),
+    );
+  }
+
+  apiUpdateFirewallRule(
+    addonId: string,
+    ruleId: string,
+    params: FirewallRuleUpdateParams,
+  ): Promise<FirewallRule> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .patch(`/databases/${addonId}/firewall_rules/${ruleId}`, {
+          firewall_rule: params,
+        }),
+      "rule",
     );
   }
 

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -15,6 +15,7 @@ import {
   DatabaseTypeVersion,
   FirewallRule,
   FirewallManagedRange,
+  FirewallRuleCreateParams,
   DbOperation,
 } from "../models/regional/databases";
 import { unpackData } from "../utils";
@@ -294,12 +295,14 @@ export default class Databases {
 
   apiCreateFirewallRule(
     addonId: string,
-    params: { type: string; cidr?: string; label?: string; range_id?: string },
+    params: FirewallRuleCreateParams,
   ): Promise<FirewallRule> {
     return unpackData(
       this._client
         .dbaasApiClient()
-        .post(`/databases/${addonId}/firewall_rules`, { firewall_rule: params }),
+        .post(`/databases/${addonId}/firewall_rules`, {
+          firewall_rule: params,
+        }),
       "rule",
     );
   }

--- a/src/models/regional/databases.ts
+++ b/src/models/regional/databases.ts
@@ -248,8 +248,6 @@ export interface FirewallRuleCreateParams {
 }
 
 export interface FirewallRuleUpdateParams {
-  cidr?: string;
-  range_id?: string;
   label?: string;
 }
 

--- a/src/models/regional/databases.ts
+++ b/src/models/regional/databases.ts
@@ -225,6 +225,21 @@ export interface DatabaseTypeVersion {
   allowed_plugins: string[] | null;
 }
 
+export interface FirewallRule {
+  id: string;
+  type: string;
+  cidr?: string;
+  range_id?: string;
+  label?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface FirewallManagedRange {
+  id: string;
+  name: string;
+}
+
 /** Detailed database information from dbaas API */
 export interface ApiDatabase {
   /** Database ID */

--- a/src/models/regional/databases.ts
+++ b/src/models/regional/databases.ts
@@ -240,6 +240,13 @@ export interface FirewallManagedRange {
   name: string;
 }
 
+export interface FirewallRuleCreateParams {
+  type: string;
+  cidr?: string;
+  range_id?: string;
+  label?: string;
+}
+
 /** Detailed database information from dbaas API */
 export interface ApiDatabase {
   /** Database ID */

--- a/src/models/regional/databases.ts
+++ b/src/models/regional/databases.ts
@@ -247,6 +247,12 @@ export interface FirewallRuleCreateParams {
   label?: string;
 }
 
+export interface FirewallRuleUpdateParams {
+  cidr?: string;
+  range_id?: string;
+  label?: string;
+}
+
 /** Detailed database information from dbaas API */
 export interface ApiDatabase {
   /** Database ID */

--- a/test/Databases/index.test.js
+++ b/test/Databases/index.test.js
@@ -309,7 +309,6 @@ describe("Databases#apiDeleteFirewallRule", () => {
 describe("Databases#apiUpdateFirewallRule", () => {
   testPatch(
     "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/firewall_rules/rule-123",
-    null,
     { firewall_rule: { label: "new label" } },
     "rule",
     (client) => {

--- a/test/Databases/index.test.js
+++ b/test/Databases/index.test.js
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import { Client } from "../../src";
 import Databases from "../../src/Databases";
 import Backups from "../../src/Databases/Backups";
-import { testGetter, testPost, testUpdate } from "../utils/http";
+import { testDelete, testGetter, testPost, testUpdate } from "../utils/http";
 
 describe("Databases#all (dashboard)", () => {
   testGetter(
@@ -256,6 +256,57 @@ describe("Databases#apiAction", () => {
       return new Databases(client).apiAction("ad-1234-5678-9012", "force-ssl", {
         enable: true,
       });
+    },
+  );
+});
+
+describe("Databases#apiFirewallRules", () => {
+  testGetter(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/firewall_rules",
+    {},
+    "rules",
+    (client) => {
+      return new Databases(client).apiFirewallRules("ad-1234-5678-9012");
+    },
+  );
+});
+
+describe("Databases#apiCreateFirewallRule", () => {
+  testPost(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/firewall_rules",
+    null,
+    { firewall_rule: { type: "managed_range", range_id: "eu", label: "eu" } },
+    "rule",
+    (client) => {
+      return new Databases(client).apiCreateFirewallRule("ad-1234-5678-9012", {
+        type: "managed_range",
+        range_id: "eu",
+        label: "eu",
+      });
+    },
+  );
+});
+
+describe("Databases#apiDeleteFirewallRule", () => {
+  testDelete(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/firewall_rules/rule-123",
+    null,
+    (client) => {
+      return new Databases(client).apiDeleteFirewallRule(
+        "ad-1234-5678-9012",
+        "rule-123",
+      );
+    },
+  );
+});
+
+describe("Databases#apiManagedFirewallRanges", () => {
+  testGetter(
+    "https://api.osc-fr1.scalingo.com/api/firewall/managed_ranges",
+    {},
+    "ranges",
+    (client) => {
+      return new Databases(client).apiManagedFirewallRanges();
     },
   );
 });

--- a/test/Databases/index.test.js
+++ b/test/Databases/index.test.js
@@ -5,7 +5,13 @@ import { expect } from "chai";
 import { Client } from "../../src";
 import Databases from "../../src/Databases";
 import Backups from "../../src/Databases/Backups";
-import { testDelete, testGetter, testPost, testUpdate } from "../utils/http";
+import {
+  testDelete,
+  testGetter,
+  testPatch,
+  testPost,
+  testUpdate,
+} from "../utils/http";
 
 describe("Databases#all (dashboard)", () => {
   testGetter(
@@ -295,6 +301,24 @@ describe("Databases#apiDeleteFirewallRule", () => {
       return new Databases(client).apiDeleteFirewallRule(
         "ad-1234-5678-9012",
         "rule-123",
+      );
+    },
+  );
+});
+
+describe("Databases#apiUpdateFirewallRule", () => {
+  testPatch(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/firewall_rules/rule-123",
+    null,
+    { firewall_rule: { label: "new label" } },
+    "rule",
+    (client) => {
+      return new Databases(client).apiUpdateFirewallRule(
+        "ad-1234-5678-9012",
+        "rule-123",
+        {
+          label: "new label",
+        },
       );
     },
   );


### PR DESCRIPTION
Add firewall rules and managed ranges support to `scalingo.js`.

This PR adds client methods for:
- listing firewall rules
- creating a firewall rule
- deleting a firewall rule
- updating a firewall rule label
- listing managed firewall ranges

This change aligns the JS client with the firewall endpoints migrated to `api` and keeps the client API consistent with the existing DBaaS behavior.