### PR TITLE
[STORY-3686][STORY-3687] tech(move db-api > api): Move databases resources endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## to be released
 
+* feat: extend `Databases.backups()` client with `show()`, `archiveUrl()`, and `restore()`
+
 ## 0.18.3
 
 * feat: add `apiInstanceMetrics()` method to fetch per-instance time-series metrics

--- a/src/Databases/Backups/index.ts
+++ b/src/Databases/Backups/index.ts
@@ -1,5 +1,5 @@
 import { Client } from "../..";
-import { Backup } from "../../models/regional/backups";
+import { Backup, BackupRestoration } from "../../models/regional/backups";
 import { unpackData } from "../../utils";
 
 /**
@@ -44,6 +44,48 @@ export default class Backups {
         .dbaasApiClient()
         .post(`/databases/${this._databaseId}/backups`, {}),
       "database_backup",
+    );
+  }
+
+  /**
+   * Retrieve a specific backup for the database
+   * @param backupId Backup ID
+   * @return Promise that when resolved returns the backup.
+   */
+  show(backupId: string): Promise<Backup> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .get(`/databases/${this._databaseId}/backups/${backupId}`),
+      "database_backup",
+    );
+  }
+
+  /**
+   * Get a download URL for a specific backup
+   * @param backupId Backup ID
+   * @return Promise that when resolved returns the download URL.
+   */
+  archiveUrl(backupId: string): Promise<string> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .get(`/databases/${this._databaseId}/backups/${backupId}/archive`),
+      "download_url",
+    );
+  }
+
+  /**
+   * Restore a specific backup
+   * @param backupId Backup ID
+   * @return Promise that when resolved returns the backup restoration object.
+   */
+  restore(backupId: string): Promise<BackupRestoration> {
+    return unpackData(
+      this._client
+        .dbaasApiClient()
+        .post(`/databases/${this._databaseId}/backups/${backupId}/restore`, {}),
+      "backup_restoration",
     );
   }
 }

--- a/src/models/regional/backups.ts
+++ b/src/models/regional/backups.ts
@@ -27,3 +27,20 @@ export interface Backup {
   /** Hidden backups are generally filtered by the API */
   hidden?: boolean;
 }
+
+export type BackupRestorationStatus =
+  | "scheduled"
+  | "running"
+  | "done"
+  | "error";
+
+export interface BackupRestoration {
+  id: string;
+  created_at: string;
+  started_at: string | null;
+  ended_at: string | null;
+  method: "backup" | "remote";
+  status: BackupRestorationStatus;
+  database_id: string;
+  source_backup_id: string;
+}

--- a/test/Databases/Backups/index.test.js
+++ b/test/Databases/Backups/index.test.js
@@ -23,3 +23,43 @@ describe("Backups#create", () => {
     },
   );
 });
+
+describe("Backups#show", () => {
+  testGetter(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/backups/backup-123",
+    {},
+    "database_backup",
+    (client) => {
+      return new Databases(client)
+        .backups("ad-1234-5678-9012")
+        .show("backup-123");
+    },
+  );
+});
+
+describe("Backups#archiveUrl", () => {
+  testGetter(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/backups/backup-123/archive",
+    {},
+    "download_url",
+    (client) => {
+      return new Databases(client)
+        .backups("ad-1234-5678-9012")
+        .archiveUrl("backup-123");
+    },
+  );
+});
+
+describe("Backups#restore", () => {
+  testPost(
+    "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/backups/backup-123/restore",
+    null,
+    {},
+    "backup_restoration",
+    (client) => {
+      return new Databases(client)
+        .backups("ad-1234-5678-9012")
+        .restore("backup-123");
+    },
+  );
+});


### PR DESCRIPTION
Add API backup member methods

Added show(backupId), archiveUrl(backupId), restore(backupId).
Updated related models/types.
Added tests for success/error cases.
download stays handled through archive URL flow.