### PR TITLE
[STORY-3686] tech(move db-api > api): Move databases resources endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## to be released
 
+## 0.18.6
+* fix: make `Databases.backups().restore()` parse raw API payload (no `backup_restoration` wrapper) to match `database-api-service` restore response
+
 ## 0.18.5
 
 * feat: add `apiPitrRestore()` method to trigger a PITR for addon

--- a/src/Databases/Backups/index.ts
+++ b/src/Databases/Backups/index.ts
@@ -85,7 +85,6 @@ export default class Backups {
       this._client
         .dbaasApiClient()
         .post(`/databases/${this._databaseId}/backups/${backupId}/restore`, {}),
-      "backup_restoration",
     );
   }
 }

--- a/test/Databases/Backups/index.test.js
+++ b/test/Databases/Backups/index.test.js
@@ -53,9 +53,9 @@ describe("Backups#archiveUrl", () => {
 describe("Backups#restore", () => {
   testPost(
     "https://api.osc-fr1.scalingo.com/api/databases/ad-1234-5678-9012/backups/backup-123/restore",
-    null,
     {},
-    "backup_restoration",
+    {},
+    undefined,
     (client) => {
       return new Databases(client)
         .backups("ad-1234-5678-9012")


### PR DESCRIPTION
fix restore endpoint: backup-restoration key is not needed