### PR TITLE
[STORY-3827] fix(move-db-api): Update action error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## to be released
 
+## 0.18.9
+
+* feat(databases): fix action empty params
+
 ## 0.18.8
 
 * feat(databases): add backup restoration show route

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -362,7 +362,7 @@ export default class Databases {
     return unpackData(
       this._client.dbaasApiClient().post(`/databases/${addonId}/action`, {
         action_name: actionName,
-        params: actionParams ?? {},
+        params: actionParams ?? "",
       }),
     );
   }

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -362,7 +362,7 @@ export default class Databases {
     return unpackData(
       this._client.dbaasApiClient().post(`/databases/${addonId}/action`, {
         action_name: actionName,
-        params: actionParams ?? "",
+        params: actionParams ?? {},
       }),
     );
   }

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -362,7 +362,7 @@ export default class Databases {
     return unpackData(
       this._client.dbaasApiClient().post(`/databases/${addonId}/action`, {
         action_name: actionName,
-        params: actionParams || {},
+        params: actionParams ?? {},
       }),
     );
   }

--- a/src/Databases/index.ts
+++ b/src/Databases/index.ts
@@ -351,13 +351,13 @@ export default class Databases {
    * Run a database action via the dbaas API
    * @param addonId ID of the database addon
    * @param actionName Name of the action to perform
-   * @param actionParams Optional parameters for the action
+   * @param actionParams Optional parameters for the action (can be an object, string, or other JSON value)
    * @return Promise that when resolved returns the action result.
    */
   apiAction(
     addonId: string,
     actionName: string,
-    actionParams?: Record<string, unknown>,
+    actionParams?: unknown,
   ): Promise<Record<string, unknown>> {
     return unpackData(
       this._client.dbaasApiClient().post(`/databases/${addonId}/action`, {


### PR DESCRIPTION
some requests returns a hash when the database action route is called
but when we want to update SQL modes, it returns a string
when we unselect all the modes, it returns a empty string
empty string was converted to {}

https://app.rollbar.com/a/Scalingo/fix/item/api/7171#detail