### PR TITLE
fix(scm-integrations): Rename exported Organizations into SCMOrganizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## to be released
 
+* fix(scm-integrations)!: rename exported `Organization`/`OrganizationsMeta` types to `SCMOrganization`/`SCMOrganizationsMeta` to avoid a naming collision with the upcoming Scalingo Organizations feature (BREAKING CHANGE for consumers importing these types)
+
 ## 0.19.2
 
 * feat(databases): Add post-provisioning configuration on databases dr

--- a/src/SCMIntegrations/index.ts
+++ b/src/SCMIntegrations/index.ts
@@ -4,9 +4,9 @@ import {
   SCMIntegration,
   PullRequest,
   Repository,
-  Organization,
+  SCMOrganization,
   Branch,
-  OrganizationsMeta,
+  SCMOrganizationsMeta,
 } from "../models/auth/scm_integrations";
 import { CreateParams } from "../params/auth/scm_integrations";
 import { unpackData } from "../utils";
@@ -148,7 +148,7 @@ export default class SCMIntegrations {
     integrationID: string,
     page: number = 1,
     per_page: number = 20,
-  ): Promise<{ organizations: Organization[]; meta: OrganizationsMeta }> {
+  ): Promise<{ organizations: SCMOrganization[]; meta: SCMOrganizationsMeta }> {
     return unpackData(
       this._client
         .authApiClient()

--- a/src/models/auth/scm_integrations.ts
+++ b/src/models/auth/scm_integrations.ts
@@ -10,10 +10,7 @@ import { User } from "./user";
  * - **gitlab-self-hosted** is a GitLab self-hosted instance
  */
 export type SCMType =
-  | "github"
-  | "gitlab"
-  | "github-enterprise"
-  | "gitlab-self-hosted";
+  "github" | "gitlab" | "github-enterprise" | "gitlab-self-hosted";
 
 /** @see https://developers.scalingo.com/scm_integrations */
 export interface SCMIntegration {

--- a/src/models/auth/scm_integrations.ts
+++ b/src/models/auth/scm_integrations.ts
@@ -10,7 +10,10 @@ import { User } from "./user";
  * - **gitlab-self-hosted** is a GitLab self-hosted instance
  */
 export type SCMType =
-  "github" | "gitlab" | "github-enterprise" | "gitlab-self-hosted";
+  | "github"
+  | "gitlab"
+  | "github-enterprise"
+  | "gitlab-self-hosted";
 
 /** @see https://developers.scalingo.com/scm_integrations */
 export interface SCMIntegration {
@@ -67,7 +70,7 @@ export interface Repository {
 }
 
 /** @see https://developers.scalingo.com/scm_integrations# */
-export interface Organization {
+export interface SCMOrganization {
   /** Unique key ID */
   id: number;
   /** URL of the avatar of the organization */
@@ -80,7 +83,7 @@ export interface Organization {
   url: string;
 }
 
-export interface OrganizationsMeta {
+export interface SCMOrganizationsMeta {
   pagination: PaginationMeta;
 }
 


### PR DESCRIPTION
Ref https://app.notion.com/p/scalingooriginal/FEAT-dashboard-Create-organization-menu-3a3f536d89bf8007885ecd8f76736da4?source=copy_link